### PR TITLE
hood: Update street sign

### DIFF
--- a/toontown/hood/StreetSign.py
+++ b/toontown/hood/StreetSign.py
@@ -11,7 +11,7 @@ class StreetSign(DistributedObject.DistributedObject):
     RedownloadTaskName = 'RedownloadStreetSign'
     StreetSignFileName = config.GetString('street-sign-filename', 'texture.jpg')
     StreetSignBaseDir = config.GetString('street-sign-base-dir', 'sign')
-    StreetSignUrl = base.config.GetString('street-sign-url', 'https://ttoffline.com/images/')
+    StreetSignUrl = base.config.GetString('street-sign-url', 'http://cdn.toontown.disney.go.com/toontown/en/street-signs/img/')
     notify = DirectNotifyGlobal.directNotify.newCategory('StreetSign')
 
     def __init__(self):


### PR DESCRIPTION
This fixes a crash when loading a street sign because the ttoffline.com website doesn't work anymore.