### PR TITLE
Fix for emotes, GM icons and spawning FOs.

### DIFF
--- a/otp/speedchat/SCEmoteTerminal.py
+++ b/otp/speedchat/SCEmoteTerminal.py
@@ -94,4 +94,4 @@ class SCEmoteTerminal(SCTerminal):
             messenger.send(self.getEventName(SCEmoteNoAccessEvent))
         elif self.__emoteEnabled():
             SCTerminal.handleSelect(self, displayType)
-            messenger.send(self.getEventName(SCEmoteMsgEvent), [self.emoteId, displayType])
+            messenger.send(self.getEventName(SCEmoteMsgEvent), [self.emoteId])

--- a/toontown/spellbook/MagicWordIndex.py
+++ b/toontown/spellbook/MagicWordIndex.py
@@ -349,7 +349,7 @@ class UnlockEmotes(MagicWord):
             emoteAccess = [0] * len(OTPLocalizer.EmoteFuncDict)
 
         for emoteId in OTPLocalizer.EmoteFuncDict.values():
-            if emoteId > 25 or emoteId in [17, 18, 19]:
+            if emoteId > 24 or emoteId in [16, 17, 18, 19]:
                 continue
             emoteAccess[emoteId] = 1
 

--- a/toontown/spellbook/MagicWordIndex.py
+++ b/toontown/spellbook/MagicWordIndex.py
@@ -1104,12 +1104,10 @@ class ToggleGM(MagicWord):
             return "You have disabled your GM icon."
         else:
             if access >= 800:
-                invoker.b_setGM(5)
+                invoker.b_setGM(4)
             elif access >= 700:
-                invoker.b_setGM(6)
+                invoker.b_setGM(4)
             elif access >=600:
-                invoker.b_setGM(8)
-                invoker.b_setGM(7)
                 invoker.b_setGM(4)
             elif access >= 500:
                 invoker.b_setGM(3)
@@ -1147,7 +1145,7 @@ class SetGM(MagicWord):
         #if gmId == 1:
         #    return 'This GM is reserved for the Toon Council. Use ~setGM 2 instead.'
 
-        if not 0 <= gmId <= 8:
+        if not 0 <= gmId <= 4:
             return "Invalid GM Icon specified."
 
         accessLevel = toon.getAccessLevel()
@@ -1158,11 +1156,11 @@ class SetGM(MagicWord):
                 return "Your access level is too low to use this GM icon."
 
         if toon.isGM() and gmId != 0:
-            toon.b_setGM(0, name)
+            toon.b_setGM(0)
         elif toon.isGM and gmId == 0:
-            toon.b_setGM(0, True)
+            toon.b_setGM(0)
 
-        toon.b_setGM(gmId, name)
+        toon.b_setGM(gmId)
 
         if __debug__:
             pass

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -4145,7 +4145,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         return False
 
     def _updateGMName(self, formerType = None):
-        return #this looks awful and doesn't work properly at the moment, use at your own inconvenience
+        return # this looks awful and doesn't work properly at the moment, use at your own inconvenience
         if formerType is None:
             formerType = self._gmType
         name = self.name

--- a/toontown/toon/DistributedToonAI.py
+++ b/toontown/toon/DistributedToonAI.py
@@ -4145,6 +4145,7 @@ class DistributedToonAI(DistributedPlayerAI.DistributedPlayerAI, DistributedSmoo
         return False
 
     def _updateGMName(self, formerType = None):
+        return #this looks awful and doesn't work properly at the moment, use at your own inconvenience
         if formerType is None:
             formerType = self._gmType
         name = self.name

--- a/toontown/toonbase/ToontownGlobals.py
+++ b/toontown/toonbase/ToontownGlobals.py
@@ -222,6 +222,10 @@ CogDeptNames = [TTLocalizer.Bossbot,
  TTLocalizer.Lawbot,
  TTLocalizer.Cashbot,
  TTLocalizer.Sellbot]
+Dept2Dept = {'s': TTLocalizer.Sellbot,
+ 'm': TTLocalizer.Cashbot,
+ 'l': TTLocalizer.Lawbot,
+ 'c': TTLocalizer.Bossbot}
 
 def cogHQZoneId2deptIndex(zone):
     if zone >= 13000 and zone <= 13999:


### PR DESCRIPTION
This pull request fixes an AI crash upon using SetGM, temporarily comments out the buggy name change for GMs (the nametag still changes font), changes the SetGM and ToggleGM magic words to not allow IDs above 4 (they don't exist) and alongside all of that fixes 'UnlockEmotes' and the use of emotes in general. This pull request also added the missing 'Dept2Dept' dict to ToontownGlobals, which fixes the AI crash upon using the 'SpawnFO' magic word.