### PR TITLE
Party Bugfixes

### DIFF
--- a/toontown/parties/DistributedPartyCatchActivity.py
+++ b/toontown/parties/DistributedPartyCatchActivity.py
@@ -224,7 +224,7 @@ class DistributedPartyCatchActivity(DistributedPartyActivity, DistributedPartyCa
         # make a dictionary of PartyCatchActivityToonSDs; they will track
         # toons' states and animate them appropriately
         self.toonSDs = {}
-        self.dropShadow = loader.loadModelOnce('phase_3/models/props/drop_shadow')
+        self.dropShadow = loader.loadModel('phase_3/models/props/drop_shadow', noCache = False)
         # load the models for the drop objects (see PartyGlobals.py)
         # index by object type name
         self.dropObjModels = {}

--- a/toontown/parties/DistributedPartyDanceActivityBase.py
+++ b/toontown/parties/DistributedPartyDanceActivityBase.py
@@ -434,7 +434,7 @@ class DistributedPartyDanceActivityBase(DistributedPartyActivity):
                                            Point3(0, 15, 10),
                                            blendType="easeIn"),
                         camera.hprInterval(0.5,
-                                           Point3(h, -20, 0),
+                                           Point3(-h, -20, 0),
                                            blendType="easeIn"),
                     ),
                     camNode.hprInterval(4.0,

--- a/toontown/parties/DistributedPartyDanceActivityBase.py
+++ b/toontown/parties/DistributedPartyDanceActivityBase.py
@@ -252,9 +252,6 @@ class DistributedPartyDanceActivityBase(DistributedPartyActivity):
         DistributedPartyActivity.joinRequestDenied(self, reason)
 
         self.showMessage(TTLocalizer.PartyActivityDefaultJoinDeny)
-        place = base.cr.playGame.getPlace()
-        if place and hasattr(place, "fsm"):
-            place.fsm.request("walk")
 
     # Distributed (broadcast ram)
     def setToonsPlaying(self, toonIds, toonHeadings):

--- a/toontown/parties/DistributedPartyDanceActivityBaseAI.py
+++ b/toontown/parties/DistributedPartyDanceActivityBaseAI.py
@@ -82,7 +82,10 @@ class DistributedPartyDanceActivityBaseAI(DistributedPartyActivityAI):
     def sendToonExitResponse(self, toonId, exited, denialReason=PartyGlobals.DenialReasons.Default):
         if exited:
             self._removeToon(toonId)
-            del self.toonIdsToHeadings[toonId]
+
+            if toonId in self.toonIdsToHeadings:
+                del self.toonIdsToHeadings[toonId]
+
             self.sendUpdate("setToonsPlaying", [self.toonIds, self.getHeadingList()])
         else:
             self.sendUpdateToAvatarId(toonId, "exitRequestDenied", [denialReason])

--- a/toontown/parties/DistributedPartyFireworksActivity.py
+++ b/toontown/parties/DistributedPartyFireworksActivity.py
@@ -92,7 +92,7 @@ class DistributedPartyFireworksActivity(DistributedPartyActivity, FireworkShowMi
         rocketLocator = self.launchPadModel.find("**/rocket_locator")
         self.rocketActor.reparentTo(rocketLocator)
         # ensure the rocket is never culled
-        self.rocketActor.node().setBound(OmniBoundingVolume())
+        self.rocketActor.node().setBounds(OmniBoundingVolume())
         self.rocketActor.node().setFinal(True)
 
         effectsLocator = self.rocketActor.find("**/joint1")

--- a/toontown/parties/DistributedPartyTrampolineActivity.py
+++ b/toontown/parties/DistributedPartyTrampolineActivity.py
@@ -342,7 +342,6 @@ class DistributedPartyTrampolineActivity(DistributedPartyActivity):
     def joinRequestDenied(self, reason):
         DistributedPartyActivity.joinRequestDenied(self, reason)
         self.showMessage(TTLocalizer.PartyActivityDefaultJoinDeny)
-        base.cr.playGame.getPlace().fsm.request("walk")
 
     def exitRequestDenied(self, reason):
         DistributedPartyActivity.exitRequestDenied(self, reason)

--- a/toontown/parties/DistributedPartyTrampolineActivity.py
+++ b/toontown/parties/DistributedPartyTrampolineActivity.py
@@ -149,7 +149,7 @@ class DistributedPartyTrampolineActivity(DistributedPartyActivity):
 
         self.sign.setPos(PartyGlobals.TrampolineSignOffset)
 
-        self.beans = [loader.loadModelCopy("phase_4/models/props/jellybean4") for i in range(self.numJellyBeans)]
+        self.beans = [loader.loadModel("phase_4/models/props/jellybean4", noCache = False) for i in range(self.numJellyBeans)]
         for bean in self.beans:
             bean.find("**/jellybean").setP(-35.0)
             bean.setScale(3.0)

--- a/toontown/parties/PartyCogActivity.py
+++ b/toontown/parties/PartyCogActivity.py
@@ -589,18 +589,19 @@ class PartyCogActivity(DirectObject):
     def handleToonExited(self, toon):
         self.finishToonIval(toon.doId)
 
-        player = self.players[toon.doId]
-        player.disable()
-        player.exitsActivity()
-        player.destroy()
+        if toon.doId in self.players:
+            player = self.players[toon.doId]
+            player.disable()
+            player.exitsActivity()
+            player.destroy()
 
-        if player == self.player:
-            self.showTeamFlags(self.activity.getTeam(toon.doId))
-            self.player = None
-            self.enableEnterGateCollision()
-            self.enableSkyCollisions()
+            if player == self.player:
+                self.showTeamFlags(self.activity.getTeam(toon.doId))
+                self.player = None
+                self.enableEnterGateCollision()
+                self.enableSkyCollisions()
 
-        del self.players[toon.doId]
+            del self.players[toon.doId]
 
     def pieThrow(self, avId, timestamp, heading, pos, power):
         """Show local or remote toon throwing a pie."""

--- a/toontown/parties/PartyEditor.py
+++ b/toontown/parties/PartyEditor.py
@@ -112,6 +112,7 @@ class PartyEditor(FSM, DirectObject):
             else:
                 pele = PartyEditorListElement(self, decorationId, isDecoration=True)
                 self.elementList.addItem(pele)
+
         self.elementList.refresh()
         self.elementList['command'] = self.scrollItemChanged
 
@@ -158,21 +159,26 @@ class PartyEditor(FSM, DirectObject):
 
     def trashCanClicked(self):
         currentTime = time.time()
+
         # Check for double click, if so, clear the party grounds
         if currentTime - self.trashCanLastClickedTime < 0.2:
             self.clearPartyGrounds()
+
         self.trashCanLastClickedTime = time.time()
 
     def clearPartyGrounds(self):
         for item in self.elementList["items"]:
             item.clearPartyGrounds()
+
         self.initPartyClock()
+
         if self.currentElement:
             self.currentElement.checkSoldOutAndPaidStatusAndAffordability()
 
     def buyCurrentElement(self):
         if self.currentElement:
             purchaseSuccessful = self.currentElement.buyButtonClicked()
+
             if purchaseSuccessful:
                 # The buying and placement of the item was successful
                 self.handleMutuallyExclusiveActivities()

--- a/toontown/parties/PartyEditorGridElement.py
+++ b/toontown/parties/PartyEditorGridElement.py
@@ -213,23 +213,30 @@ class PartyEditorGridElement(DirectButton):
         # assert self.notify.debug("uprightNodePathR=%s" % self.uprightNodePath.getR())
 
     def setPosHprBasedOnGridSquare(self, gridSquare):
+        aspectRatio = base.camLens.getAspectRatio()
+        if aspectRatio >= 1.6:
+            gridCenter = PartyGlobals.PartyEditorGridCenterWidescreen
+            gridSquareSize = PartyGlobals.PartyEditorGridSquareSizeWidescreen
+        else:
+            gridCenter = PartyGlobals.PartyEditorGridCenter
+            gridSquareSize = PartyGlobals.PartyEditorGridSquareSize
         gridPos = gridSquare.getPos()
         # Move the position over if the element has any even dimensions
         if self.getGridSize()[0] % 2 == 0:
-            gridPos.setX(gridPos[0]+PartyGlobals.PartyEditorGridSquareSize[0]/2.0)
+            gridPos.setX(gridPos[0]+gridSquareSize[0]/2.0)
         if self.getGridSize()[1] % 2 == 0:
-            gridPos.setZ(gridPos[2]+PartyGlobals.PartyEditorGridSquareSize[1]/2.0)
+            gridPos.setZ(gridPos[2]+gridSquareSize[1]/2.0)
         # Rotate the element so it always faces towards the center of the grid
         if self.id != PartyGlobals.ActivityIds.PartyFireworks:
-            if gridPos[0] > PartyGlobals.PartyEditorGridCenter[0] + PartyGlobals.PartyEditorGridRotateThreshold:
+            if gridPos[0] > gridCenter[0] + PartyGlobals.PartyEditorGridRotateThreshold:
                 self.setR(90.0)
                 self.uprightNodePath.setR(-90.0)
                 # assert self.notify.debug("uprightNodePathR=%s" % self.uprightNodePath.getR())
-            elif gridPos[0] < PartyGlobals.PartyEditorGridCenter[0] - PartyGlobals.PartyEditorGridRotateThreshold:
+            elif gridPos[0] < gridCenter[0] - PartyGlobals.PartyEditorGridRotateThreshold:
                 self.setR(270.0)
                 self.uprightNodePath.setR(-270.0)
                 # assert self.notify.debug("uprightNodePathR=%s" % self.uprightNodePath.getR())
-            elif gridPos[2] < PartyGlobals.PartyEditorGridCenter[1] - PartyGlobals.PartyEditorGridRotateThreshold:
+            elif gridPos[2] < gridCenter[1] - PartyGlobals.PartyEditorGridRotateThreshold:
                 self.setR(180.0)
                 self.uprightNodePath.setR(-180.0)
                 # assert self.notify.debug("uprightNodePathR=%s" % self.uprightNodePath.getR())
@@ -246,10 +253,17 @@ class PartyEditorGridElement(DirectButton):
         self.lastValidPosition = gridPos
 
     def getGridSquareFromPosition(self, newPos):
-        localX = newPos[0] - PartyGlobals.PartyEditorGridBounds[0][0]
-        localY = newPos[2] - PartyGlobals.PartyEditorGridBounds[1][1]
-        x = int(localX / PartyGlobals.PartyEditorGridSquareSize[0])
-        y = int(localY / PartyGlobals.PartyEditorGridSquareSize[1])
+        aspectRatio = base.camLens.getAspectRatio()
+        if aspectRatio >= 1.6:
+            bounds = PartyGlobals.PartyEditorGridBoundsWidescreen
+            gridSquareSize = PartyGlobals.PartyEditorGridSquareSizeWidescreen
+        else:
+            bounds = PartyGlobals.PartyEditorGridBounds
+            gridSquareSize = PartyGlobals.PartyEditorGridSquareSize
+        localX = newPos[0] - bounds[0][0]
+        localY = newPos[2] - bounds[1][1]
+        x = int(localX / gridSquareSize[0])
+        y = int(localY / gridSquareSize[1])
         # Reverse y value because y goes from bottom to top
         y = PartyGlobals.PartyEditorGridSize[1] - 1 - y
         return self.partyEditor.partyEditorGrid.getGridSquare(x,y)

--- a/toontown/parties/PartyEditorGridSquare.py
+++ b/toontown/parties/PartyEditorGridSquare.py
@@ -32,10 +32,18 @@ class PartyEditorGridSquare(DirectObject):
         self.gridElement = None
 
     def getPos(self):
+        aspectRatio = base.camLens.getAspectRatio()
+        if aspectRatio >= 1.6:
+            bounds = PartyGlobals.PartyEditorGridBoundsWidescreen
+            squareSize = PartyGlobals.PartyEditorGridSquareSizeWidescreen
+        else:
+            bounds = PartyGlobals.PartyEditorGridBounds
+            squareSize = PartyGlobals.PartyEditorGridSquareSize
+
         return Point3(
-            PartyGlobals.PartyEditorGridBounds[0][0] + self.x*PartyGlobals.PartyEditorGridSquareSize[0] + PartyGlobals.PartyEditorGridSquareSize[0]/2.0,
+            bounds[0][0] + self.x*squareSize[0] + squareSize[0]/2.0,
             0.0,
-            PartyGlobals.PartyEditorGridBounds[1][1] + (PartyGlobals.PartyEditorGridSize[1]-1-self.y)*PartyGlobals.PartyEditorGridSquareSize[1] + PartyGlobals.PartyEditorGridSquareSize[1]/2.0,
+            bounds[1][1] + (PartyGlobals.PartyEditorGridSize[1]-1-self.y)*squareSize[1] + squareSize[1]/2.0,
         )
 
     def destroy(self):

--- a/toontown/parties/PartyGlobals.py
+++ b/toontown/parties/PartyGlobals.py
@@ -68,6 +68,17 @@ PartyEditorGridSquareSize = (
     (PartyEditorGridBounds[1][0] - PartyEditorGridBounds[0][0]) / float(PartyEditorGridSize[0]),
     (PartyEditorGridBounds[0][1] - PartyEditorGridBounds[1][1]) / float(PartyEditorGridSize[1]),
 )
+
+PartyEditorGridBoundsWidescreen  =  ((-0.075, 0.289), (0.39, -0.447))
+PartyEditorGridCenterWidescreen = (
+    PartyEditorGridBoundsWidescreen[0][0] + (PartyEditorGridBoundsWidescreen[1][0] - PartyEditorGridBoundsWidescreen[0][0])/2.0,
+    PartyEditorGridBoundsWidescreen[1][1] + (PartyEditorGridBoundsWidescreen[0][1] - PartyEditorGridBoundsWidescreen[1][1])/2.0,
+)
+PartyEditorGridSquareSizeWidescreen  = (
+    (PartyEditorGridBoundsWidescreen[1][0] - PartyEditorGridBoundsWidescreen[0][0]) / float(PartyEditorGridSize[0]),
+    (PartyEditorGridBoundsWidescreen[0][1] - PartyEditorGridBoundsWidescreen[1][1]) / float(PartyEditorGridSize[1]),
+)
+
 PartyEditorGridRotateThreshold = 0.08
 
 # The number of squares in which players can place activities or decorations.

--- a/toontown/parties/TeamActivityGui.py
+++ b/toontown/parties/TeamActivityGui.py
@@ -125,11 +125,13 @@ class TeamActivityGui:
 #===============================================================================
 
     def showStatus(self, text):
-        self.statusText.setText(text)
-        self.statusText.show()
+        if self.statusText is not None:
+            self.statusText.setText(text)
+            self.statusText.show()
 
     def hideStatus(self):
-        self.statusText.hide()
+        if self.statusText is not None:
+            self.statusText.hide()
 
 #===============================================================================
 # Exit
@@ -141,7 +143,8 @@ class TeamActivityGui:
     def disableExitButton(self):
         assert(self.activity.notify.debug("GUI: disableExitButton"))
 
-        self.exitButton.hide()
+        if self.exitButton is not None:
+            self.exitButton.hide()
 
     def handleExitButtonClick(self):
         self.disableExitButton()

--- a/toontown/toon/DistributedNPCPartyPerson.py
+++ b/toontown/toon/DistributedNPCPartyPerson.py
@@ -230,7 +230,7 @@ class DistributedNPCPartyPerson(DistributedNPCToonBase):
             if self.isInteractingWithLocalToon:
                 base.localAvatar.aboutToPlanParty = True
                 base.cr.partyManager.setPartyPlannerStyle(self.style)
-                base.cr.partyManager.setPartyPlannerName(self.name)
+                base.cr.partyManager.setPartyPlannerName(self.getName())
                 base.localAvatar.creatingNewPartyWithMagicWord = False
                 loaderId = "safeZoneLoader"
                 whereId = "party"

--- a/toontown/uberdog/DistributedPartyManagerAI.py
+++ b/toontown/uberdog/DistributedPartyManagerAI.py
@@ -898,7 +898,7 @@ class DistributedPartyManagerAI(DistributedObjectAI):
 
     # Send Party Zone information back to the client
     def __sendPartyZoneToClient(self, avId, hostId):
-        self.notify.warning("__sendPartyZoneToClient called with avId=%d, hostId=%d" % (avId, hostId))
+        self.notify.info("__sendPartyZoneToClient called with avId=%d, hostId=%d" % (avId, hostId))
         try:
             zoneId = self.avIdToPartyZoneId[avId]
             partyId = self.hostAvIdToPartiesRunning[hostId].partyInfo.partyId


### PR DESCRIPTION
This pull request has done the following:
- Fixed all deprecated warnings when visiting a party due to party code using old methods for loading models
- Fix camera bug when on the dance floor and a new dance move is learned. Previously the screen would freak out before returning back to the toon.
- Added widescreen support to the party planner screen to fix issues with the party pieces being placed off the map
- Fixed party planner name containing the DoID when a party is planned
- Fixed a district crash that could happen if a user exists the dance floor but was not inside of the toonIdsToHeadings's array.